### PR TITLE
[review] Android Retrofit Request Code

### DIFF
--- a/app/src/main/java/meaning/morning/network/request/RequestCallbackReview.kt
+++ b/app/src/main/java/meaning/morning/network/request/RequestCallbackReview.kt
@@ -1,0 +1,58 @@
+/*
+ * Created by jinsu4755
+ * DESC: callback 객체 구현하는 Request Class 시도해봄 그냥 궁금해서
+ */
+
+package meaning.morning.network.request
+
+import android.text.TextUtils
+import android.util.Log
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
+import meaning.morning.network.response.BaseResponse
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class RequestCallbackReview<T> : Callback<BaseResponse<T>> {
+
+    private var onSuccessListener: ((BaseResponse<T>) -> Unit)? = null
+    private var onErrorListener: ((BaseResponse<Unit>) -> Unit)? = null
+    private var onFailureListener: ((t: Throwable) -> Unit)? = null
+
+    fun onSuccessListener(listener: ((BaseResponse<T>) -> Unit)) {
+        this.onSuccessListener = listener
+    }
+
+    fun onErrorListener(listener: (BaseResponse<Unit>) -> Unit) {
+        this.onErrorListener = listener
+    }
+
+    fun onFailureListener(listener: (t: Throwable) -> Unit) {
+        this.onFailureListener = listener
+    }
+
+    override fun onResponse(call: Call<BaseResponse<T>>, response: Response<BaseResponse<T>>) {
+        if (response.isSuccessful) {
+            onSuccessListener?.invoke(response.body() ?: return)
+            return
+        }
+        val errorBody = response.errorBody()?.string() ?: return
+        val errorResponse = createResponseErrorBody(errorBody)
+        onErrorListener?.invoke(errorResponse)
+    }
+
+    private fun createResponseErrorBody(errorBody: String): BaseResponse<Unit> {
+        val gson = GsonBuilder().create()
+        val responseType = object : TypeToken<BaseResponse<T>>() {}.type
+        return gson.fromJson(errorBody, responseType)
+    }
+
+    override fun onFailure(call: Call<BaseResponse<T>>, t: Throwable) {
+        Log.d("jinsu4755", "${t.message} \n")
+        Log.d("jinsu4755", "${t.localizedMessage} \n")
+        Log.d("jinsu4755", TextUtils.join("\n", t.stackTrace))
+        onFailureListener?.invoke(t)
+    }
+}
+

--- a/app/src/main/java/meaning/morning/network/request/TimeStampPostRequestReview.kt
+++ b/app/src/main/java/meaning/morning/network/request/TimeStampPostRequestReview.kt
@@ -1,0 +1,46 @@
+/*
+ * Created by jinsu4755
+ * DESC:
+ */
+
+package meaning.morning.network.request
+
+import meaning.morning.network.MeaningService
+import meaning.morning.network.response.TimeStampResponse
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+class TimeStampPostRequestReview(
+    private val dateTime: String,
+    private val timeStampContent: String,
+    private val image: MultipartBody.Part,
+) {
+    private var callback: RequestCallbackReview<TimeStampResponse>? = null
+
+    fun setEvent(block: RequestCallback<TimeStampResponse>.() -> Unit): TimeStampPostRequestReview {
+        callback = RequestCallbackReview<TimeStampResponse>().apply(block)
+        return this
+    }
+
+    fun send(token: String?) {
+        MeaningService.getInstance()
+            .requestPostTimestamp(
+                token = token,
+                params = createPartMap(),
+                image = image
+            ).enqueue(callback ?: return)
+    }
+
+    private fun createPartMap(): HashMap<String, RequestBody> {
+        val partMap = HashMap<String, RequestBody>()
+        partMap["dateTime"] = dateTime.toRequestBody(MEDIA_TYPE_TEXT)
+        partMap["timeStampContents"] = timeStampContent.toRequestBody(MEDIA_TYPE_TEXT)
+        return partMap
+    }
+
+    companion object {
+        private val MEDIA_TYPE_TEXT = "text/plain".toMediaType()
+    }
+}

--- a/app/src/main/java/meaning/morning/network/request/TimeStampPostRequestReview.kt
+++ b/app/src/main/java/meaning/morning/network/request/TimeStampPostRequestReview.kt
@@ -19,7 +19,7 @@ class TimeStampPostRequestReview(
 ) {
     private var callback: RequestCallbackReview<TimeStampResponse>? = null
 
-    fun setEvent(block: RequestCallback<TimeStampResponse>.() -> Unit): TimeStampPostRequestReview {
+    fun setEvent(block: RequestCallbackReview<TimeStampResponse>.() -> Unit): TimeStampPostRequestReview {
         callback = RequestCallbackReview<TimeStampResponse>().apply(block)
         return this
     }


### PR DESCRIPTION
# Description 

Request 부분 코드 작성

고려사항.
**BaseRequest?** 
callback을 구현하는것이 Request의 진짜 하위일까?
그랬다면 애초에 call.enque의 형식이 아니지 않을까? 
call객체에 enqueue라는 callback을 구현해서 넣어주는 이유에 어긋 나는 부분일 것 같다 생각
우리가 만드는 Request는 메소드 호출로 반환된 call에 callback을 전달해주는 형식이라 생각함.
-> 상속구조를 하지 않기로 마음 먹음

**그럼 중복 코드는?** 
사실 이렇게 만들면 Reqeust라는 클래스 안에 반드시 Callback 인스턴스를 가지고 그것을 apply하는 코드를 적어야함
그렇다고 이 코드 중복을 제거하는 상속구조?는 상속이란 개념에서 어긋났다고 생각했음.
차라리 확장함수를 정의해서 둘까? 생각했으나 시간상 빠위..

**Request의 범위는 뭐지?** 
![image](https://user-images.githubusercontent.com/45380072/104819408-9f78af00-5870-11eb-8b24-4e3a5c3aa572.png)
우리가 쓰는 enqueue는 execute부분에서 호출될것이며 비동기로 받아오기에 비동기로 받았을때 어떤일을 할지 정의해주는 부분이 Request의 범위라고 생각했음

**즉 Requet라는 객체는 우리가 서버에 어떤데이터를 보내고 어떤 일을 할지 지정하는 책임**이 있다고 생각함.

그렇기에 callback을 상속이 아닌 내부에 인스턴스로 가지도록 함.

그리고 Request에서 보낼 데이터를 가공함.

생성자로 들어올 매개 변수가 많은 경우는 DataCalss로 받을 생각함.

결국 이 경우에 컴포지션을 어떻게 해야할지 감이 안잡힘 이팩티브 자바 예시는 Set이 달려있는데 그걸 이해하지 못하는 한계와 자신의 부족함으로 인해 현타옴

젠장.... 난 감자야... ㅅㅂ 말하는 감자...


## 참고

해당 부분 코드리뷰를 위해서 일부러 이름에 Review를 붙였습니다. 원래 Review가 없다고 생각해주시면 됩니다.


### 희망 리뷰 완료일

`없음 혁이형 편할때 한가할때 해주면 진짜 매우 감사 ㅇㅈ?`